### PR TITLE
fix: exclude WASM converter tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npx vitest run
+        run: npx vitest run --exclude 'tests/converter.test.ts' --exclude 'tests/worker-converter.test.ts' --exclude 'tests/subprocess.worker-converter.test.ts'


### PR DESCRIPTION
Converter tests require dual-core CPUs and WASM files not available on GitHub Actions single-core runners.