### PR TITLE
Publish browser assets to GitHub Pages with an in-browser demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,103 @@
+name: Deploy WASM to GitHub Pages
+
+# Publishes the browser runtime assets (dist/ + wasm/) to GitHub Pages so they can
+# be loaded cross-origin. GitHub Pages serves every file with
+# `Access-Control-Allow-Origin: *`, which is what browsers require to fetch the
+# LibreOffice WASM binaries (soffice.wasm / soffice.data) from another origin.
+#
+# Deploying via the Pages *artifact* (instead of committing to a branch) sidesteps
+# the 100 MB per-file git limit, so the ~140 MB soffice.wasm can be published.
+#
+# The site serves the currently published release only. Consumers should pin their
+# local JS glue (dist/) to the same version they load the binaries for.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Least-privilege token: only what the Pages deployment needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one Pages deployment at a time; never cancel an in-progress deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with LFS binaries)
+        uses: actions/checkout@v7
+        with:
+          lfs: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build browser bundle (dist/)
+        run: npm run build
+
+      - name: Verify WASM binaries were pulled from LFS
+        run: |
+          set -euo pipefail
+          for f in wasm/soffice.wasm wasm/soffice.data; do
+            size=$(wc -c < "$f")
+            echo "$f: $size bytes"
+            if [ "$size" -lt 1000000 ]; then
+              echo "::error::$f is only $size bytes — it looks like a Git LFS pointer. LFS content was not pulled."
+              exit 1
+            fi
+          done
+
+      - name: Assemble Pages site
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          rm -rf _site
+          mkdir -p _site
+          # Mirror the npm package browser layout so consumers can use the same paths.
+          cp -R dist _site/dist
+          cp -R wasm _site/wasm
+          # Disable Jekyll so files are served verbatim (and nothing is dropped).
+          touch _site/.nojekyll
+          # Version marker (the landing page fetches this to show the version).
+          printf '{ "version": "%s" }\n' "$VERSION" > _site/version.json
+          # Landing page + demo (source: pages/). Includes the coi-serviceworker
+          # so the demo's SharedArrayBuffer works on GitHub Pages (no COOP/COEP).
+          cp pages/index.html _site/index.html
+          cp pages/coi-serviceworker.js _site/coi-serviceworker.js
+          echo "Assembled site:"
+          du -sh _site
+          du -h _site/wasm/soffice.wasm _site/wasm/soffice.data
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/pages/coi-serviceworker.js
+++ b/pages/coi-serviceworker.js
@@ -1,0 +1,135 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof, licensed under MIT */
+/*
+ * Enables Cross-Origin Isolation on hosts that cannot set COOP/COEP response
+ * headers (such as GitHub Pages). The service worker intercepts requests and
+ * adds the headers so SharedArrayBuffer becomes available, which the LibreOffice
+ * WASM runtime requires. It is a no-op when the page is already cross-origin
+ * isolated.
+ */
+
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then((clients) => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request =
+            coepCredentialless && r.mode === "no-cors"
+                ? new Request(r, {
+                    credentials: "omit",
+                })
+                : r;
+
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+                    newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf === "coepDegrade");
+
+        // You can customize the behavior of this script by setting coi configuration
+        // on the global scope before loading.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => {
+                window.sessionStorage.setItem("coiReloadedBySelf",
+                    coepDegrading ? "coepDegrade" : "true");
+                window.location.reload();
+            },
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+
+        if (coi.shouldDeregister()) {
+            n.serviceWorker &&
+                n.serviceWorker.controller &&
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+        }
+
+        // If we're already cross-origin isolated, no need for the service worker
+        if (window.crossOriginIsolated) {
+            !coi.quiet && console.log("Documentate COI: already cross-origin isolated");
+            return;
+        }
+
+        if (!coi.shouldRegister()) {
+            !coi.quiet && console.log("Documentate COI: will not register (already reloaded)");
+            return;
+        }
+
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("Documentate COI: ServiceWorker API not available");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("Documentate COI: Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Documentate COI: update found, reloading page");
+                    coi.doReload();
+                });
+
+                // If the service worker is already active, reload immediately
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Documentate COI: active, reloading page");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("Documentate COI: registration failed", err);
+            }
+        );
+    })();
+}

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LibreOffice WASM assets — CDN</title>
+<meta name="description" content="Cross-origin CDN for the @matbee/libreoffice-converter browser runtime: LibreOffice WASM assets served with CORS for in-browser document conversion. Includes a live demo.">
+<!-- Enables cross-origin isolation (SharedArrayBuffer) on hosts that can't send
+     COOP/COEP headers, e.g. GitHub Pages. No-op when headers are already set. -->
+<script src="coi-serviceworker.js"></script>
+<style>
+	:root {
+		--bg: #ffffff; --fg: #1b1f23; --muted: #5b636b; --border: #e6e8eb; --card: #f6f8fa;
+		--accent: #18a303; --accent-ink: #0c6b00;
+		--code-bg: #0d1117; --code-fg: #e6edf3; --code-comment: #8b949e; --code-accent: #7ee787;
+	}
+	@media (prefers-color-scheme: dark) {
+		:root {
+			--bg: #0d1117; --fg: #e6edf3; --muted: #9aa4ae; --border: #262d36; --card: #161b22;
+			--accent: #43c463; --accent-ink: #7ee787; --code-bg: #010409;
+		}
+	}
+	* { box-sizing: border-box; }
+	html { -webkit-text-size-adjust: 100%; }
+	body {
+		margin: 0; background: var(--bg); color: var(--fg);
+		font: 16px/1.65 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+		-webkit-font-smoothing: antialiased;
+	}
+	.wrap { max-width: 760px; margin: 0 auto; padding: clamp(24px, 6vw, 64px) 20px 72px; }
+	a { color: var(--accent-ink); text-decoration: none; }
+	a:hover { text-decoration: underline; }
+
+	header { border-bottom: 1px solid var(--border); padding-bottom: 28px; margin-bottom: 36px; }
+	.eyebrow { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase; color: var(--accent-ink); }
+	.dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); }
+	h1 { font-size: clamp(28px, 6vw, 40px); line-height: 1.1; margin: 14px 0 10px; letter-spacing: -.02em; }
+	.lede { font-size: clamp(16px, 2.4vw, 19px); color: var(--muted); margin: 0; max-width: 60ch; }
+	.badge { display: inline-block; margin-top: 18px; padding: 4px 12px; border-radius: 999px; background: var(--card); border: 1px solid var(--border); font: 500 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
+	.badge b { color: var(--fg); }
+
+	h2 { font-size: 15px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 40px 0 14px; }
+	p { margin: 0 0 16px; }
+	code:not(pre code) { font: 500 .88em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: .1em .4em; }
+
+	/* Demo */
+	.demo { border: 1px solid var(--border); border-radius: 14px; background: var(--card); padding: 22px; }
+	.drop { border: 1.5px dashed var(--border); border-radius: 12px; padding: 28px 20px; text-align: center; transition: border-color .15s, background .15s; cursor: pointer; }
+	.drop.over { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+	.drop strong { color: var(--fg); }
+	.drop small { color: var(--muted); display: block; margin-top: 6px; }
+	.demo-row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 16px; }
+	.btn { appearance: none; border: 0; border-radius: 9px; padding: 10px 18px; font: 600 14px system-ui, sans-serif; color: #fff; background: var(--accent); cursor: pointer; }
+	.btn:disabled { opacity: .5; cursor: not-allowed; }
+	.btn.secondary { background: transparent; color: var(--accent-ink); border: 1px solid var(--border); }
+	.demo-file { font: 500 13px ui-monospace, monospace; color: var(--muted); }
+	.demo-status { margin-top: 14px; font-size: 14px; color: var(--muted); min-height: 1.2em; }
+	.demo-status.err { color: #d63638; }
+	.demo-status.ok { color: var(--accent-ink); }
+	.bar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 12px; display: none; }
+	.bar > i { display: block; height: 100%; width: 0; background: var(--accent); transition: width .2s; }
+	.hint { font-size: 12.5px; color: var(--muted); margin-top: 12px; }
+
+	.code { position: relative; margin: 0 0 8px; background: var(--code-bg); border-radius: 12px; border: 1px solid var(--border); overflow: hidden; }
+	.code pre { margin: 0; padding: 20px 18px; overflow-x: auto; }
+	.code code { font: 13.5px/1.7 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--code-fg); white-space: pre; }
+	.code .c { color: var(--code-comment); }
+	.code .k { color: var(--code-accent); }
+	.copy { position: absolute; top: 10px; right: 10px; font: 600 12px system-ui, sans-serif; color: var(--code-fg); background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.14); border-radius: 7px; padding: 5px 10px; cursor: pointer; }
+	.copy:hover { background: rgba(255,255,255,.16); }
+
+	ul.files { list-style: none; margin: 0; padding: 0; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+	ul.files li { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 11px 16px; border-top: 1px solid var(--border); }
+	ul.files li:first-child { border-top: 0; }
+	ul.files li:nth-child(odd) { background: var(--card); }
+	ul.files a { font: 500 14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+	ul.files .size { font: 500 12px ui-monospace, monospace; color: var(--muted); white-space: nowrap; }
+
+	.note { background: var(--card); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; padding: 14px 16px; color: var(--muted); font-size: 14.5px; }
+	.note b { color: var(--fg); }
+
+	footer { margin-top: 52px; padding-top: 24px; border-top: 1px solid var(--border); color: var(--muted); font-size: 14px; display: flex; gap: 18px; flex-wrap: wrap; }
+</style>
+</head>
+<body>
+<div class="wrap">
+	<header>
+		<span class="eyebrow"><span class="dot"></span>LibreOffice · WebAssembly · CDN</span>
+		<h1>LibreOffice WASM assets</h1>
+		<p class="lede">A cross-origin host for the <a href="https://www.npmjs.com/package/@matbee/libreoffice-converter"><code>@matbee/libreoffice-converter</code></a> browser runtime. Every file is served with <code>Access-Control-Allow-Origin: *</code>, so you can load the ~235&nbsp;MB LibreOffice WebAssembly runtime from another origin and convert documents entirely in the browser.</p>
+		<span class="badge" id="version">version <b>…</b></span>
+	</header>
+
+	<section>
+		<h2>Try it</h2>
+		<div class="demo">
+			<div class="drop" id="drop" tabindex="0" role="button" aria-label="Choose or drop a document">
+				<strong id="drop-label">Drop a document here, or click to choose</strong>
+				<small>.odt, .docx, .xlsx, .pptx, .rtf … → PDF, in your browser</small>
+				<input type="file" id="file" accept=".odt,.ods,.odp,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.rtf,.txt,.csv,.html" hidden>
+			</div>
+			<div class="demo-row">
+				<button class="btn" id="convert" disabled>Convert to PDF</button>
+				<a class="btn secondary" id="download" style="display:none" download>Download PDF</a>
+				<span class="demo-file" id="filename"></span>
+			</div>
+			<div class="bar" id="bar"><i></i></div>
+			<div class="demo-status" id="status"></div>
+			<p class="hint">First run downloads the LibreOffice WASM runtime (~235&nbsp;MB) and can take a minute; it is then cached by the browser. Everything runs locally — files never leave your device.</p>
+		</div>
+	</section>
+
+	<section>
+		<h2>What is this?</h2>
+		<p>The npm package ships the LibreOffice WASM binaries (<code>soffice.wasm</code> ≈ 140&nbsp;MB, <code>soffice.data</code> ≈ 95&nbsp;MB), which are too large for public npm CDNs and can't be committed into most projects. This page mirrors that browser runtime on GitHub Pages so it can be fetched cross-origin — and runs the demo above from the very same files.</p>
+	</section>
+
+	<section>
+		<h2>Quick start</h2>
+		<div class="code">
+			<button class="copy" type="button" data-copy>Copy</button>
+			<pre><code id="snippet"><span class="c">// npm i @matbee/libreoffice-converter</span>
+<span class="k">import</span> { WorkerBrowserConverter, createWasmPaths } <span class="k">from</span> '@matbee/libreoffice-converter/browser';
+
+<span class="c">// A Worker script can't be loaded cross-origin, so keep the small JS glue</span>
+<span class="c">// (dist/ + soffice.js + soffice.worker.js) same-origin and load only the</span>
+<span class="c">// two heavy binaries from this CDN.</span>
+<span class="k">const</span> CDN = '__ORIGIN__';
+
+<span class="k">const</span> converter = <span class="k">new</span> WorkerBrowserConverter({
+  ...createWasmPaths('/wasm/'),               <span class="c">// soffice.js + soffice.worker.js: same-origin</span>
+  sofficeWasm: `${CDN}/wasm/soffice.wasm`,     <span class="c">// ≈140 MB from the CDN</span>
+  sofficeData: `${CDN}/wasm/soffice.data`,     <span class="c">// ≈95 MB from the CDN</span>
+});
+
+<span class="k">await</span> converter.initialize();
+<span class="k">const</span> { data } = <span class="k">await</span> converter.convert(fileBytes, { outputFormat: 'pdf' }, 'doc.docx');</code></pre>
+		</div>
+	</section>
+
+	<section>
+		<h2>Files</h2>
+		<ul class="files">
+			<li><a href="./dist/browser.js">dist/browser.js</a><span class="size">entrypoint</span></li>
+			<li><a href="./dist/browser.worker.global.js">dist/browser.worker.global.js</a><span class="size">worker</span></li>
+			<li><a href="./wasm/soffice.js">wasm/soffice.js</a><span class="size">loader</span></li>
+			<li><a href="./wasm/soffice.wasm">wasm/soffice.wasm</a><span class="size">≈140 MB</span></li>
+			<li><a href="./wasm/soffice.data">wasm/soffice.data</a><span class="size">≈95 MB</span></li>
+			<li><a href="./wasm/soffice.worker.js">wasm/soffice.worker.js</a><span class="size">pthread</span></li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>Requirements</h2>
+		<p class="note"><b>Cross-origin isolation.</b> The converter uses <code>SharedArrayBuffer</code>, so the page that runs it must be served with <code>Cross-Origin-Opener-Policy: same-origin</code> and <code>Cross-Origin-Embedder-Policy: require-corp</code> (or <code>credentialless</code>). GitHub Pages can't set these, so this page uses a <a href="https://github.com/gzuidhof/coi-serviceworker">service worker</a> to enable isolation client-side; in your own app, set the headers on the server.</p>
+	</section>
+
+	<footer>
+		<a href="https://github.com/erseco/libreoffice-document-converter">Source repository</a>
+		<a href="https://www.npmjs.com/package/@matbee/libreoffice-converter">npm package</a>
+		<span>Served from GitHub Pages · not for heavy production traffic</span>
+	</footer>
+</div>
+
+<script>
+	// Base URL (directory of this page) — robust at "/" or "/index.html".
+	var base = new URL('.', location.href).href.replace(/\/$/, '');
+	var snip = document.getElementById('snippet');
+	snip.innerHTML = snip.innerHTML.replace('__ORIGIN__', base);
+	fetch('./version.json').then(function (r) { return r.json(); }).then(function (d) {
+		document.querySelector('#version b').textContent = d.version;
+	}).catch(function () { document.getElementById('version').style.display = 'none'; });
+	document.querySelector('[data-copy]').addEventListener('click', function (e) {
+		navigator.clipboard.writeText(document.getElementById('snippet').innerText).then(function () {
+			e.target.textContent = 'Copied'; setTimeout(function () { e.target.textContent = 'Copy'; }, 1500);
+		});
+	});
+</script>
+
+<script type="module">
+	import { WorkerBrowserConverter, createWasmPaths } from './dist/browser.js';
+
+	const drop = document.getElementById('drop');
+	const fileInput = document.getElementById('file');
+	const convertBtn = document.getElementById('convert');
+	const downloadLink = document.getElementById('download');
+	const filenameEl = document.getElementById('filename');
+	const statusEl = document.getElementById('status');
+	const dropLabel = document.getElementById('drop-label');
+	const bar = document.getElementById('bar');
+	const barFill = bar.querySelector('i');
+
+	const BASE = new URL('.', location.href).href; // absolute; workers resolve relative URLs against themselves.
+	let selectedFile = null;
+	let converter = null;
+
+	function setStatus(msg, kind) { statusEl.textContent = msg; statusEl.className = 'demo-status' + (kind ? ' ' + kind : ''); }
+	function setProgress(pct) { bar.style.display = pct == null ? 'none' : 'block'; if (pct != null) barFill.style.width = Math.max(3, pct) + '%'; }
+
+	function pick(file) {
+		if (!file) return;
+		selectedFile = file;
+		filenameEl.textContent = file.name;
+		dropLabel.textContent = file.name;
+		convertBtn.disabled = false;
+		downloadLink.style.display = 'none';
+		setStatus('');
+	}
+
+	drop.addEventListener('click', () => fileInput.click());
+	drop.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInput.click(); } });
+	fileInput.addEventListener('change', () => pick(fileInput.files[0]));
+	drop.addEventListener('dragover', (e) => { e.preventDefault(); drop.classList.add('over'); });
+	drop.addEventListener('dragleave', () => drop.classList.remove('over'));
+	drop.addEventListener('drop', (e) => { e.preventDefault(); drop.classList.remove('over'); pick(e.dataTransfer.files[0]); });
+
+	async function getConverter() {
+		if (converter) return converter;
+		if (!self.crossOriginIsolated) {
+			throw new Error('Cross-origin isolation is not active, so SharedArrayBuffer is unavailable. Reload the page; if it persists, your browser blocks the service worker.');
+		}
+		converter = new WorkerBrowserConverter({
+			...createWasmPaths(BASE + 'wasm/'),
+			browserWorkerJs: BASE + 'dist/browser.worker.global.js',
+			onProgress: (info) => {
+				if (info) { setStatus(info.message || 'Working…'); if (typeof info.percent === 'number') setProgress(info.percent); }
+			},
+		});
+		await converter.initialize();
+		return converter;
+	}
+
+	convertBtn.addEventListener('click', async () => {
+		if (!selectedFile) return;
+		convertBtn.disabled = true;
+		downloadLink.style.display = 'none';
+		setProgress(0);
+		setStatus('Loading LibreOffice…');
+		const started = performance.now();
+		try {
+			const c = await getConverter();
+			setStatus('Converting ' + selectedFile.name + '…');
+			const bytes = new Uint8Array(await selectedFile.arrayBuffer());
+			const result = await c.convert(bytes, { outputFormat: 'pdf' }, selectedFile.name);
+			const blob = new Blob([result.data], { type: result.mimeType || 'application/pdf' });
+			const url = URL.createObjectURL(blob);
+			downloadLink.href = url;
+			downloadLink.download = selectedFile.name.replace(/\.[^.]+$/, '') + '.pdf';
+			downloadLink.style.display = 'inline-block';
+			const secs = ((performance.now() - started) / 1000).toFixed(1);
+			const kb = (result.data.length / 1024).toFixed(0);
+			setStatus('Done — ' + kb + ' KB PDF in ' + secs + ' s.', 'ok');
+			setProgress(null);
+			// Expose result for automated verification.
+			window.__demoResult = { ok: true, bytes: result.data.length, mime: result.mimeType, isPdf: result.data[0] === 0x25 && result.data[1] === 0x50 };
+		} catch (err) {
+			setStatus(err && err.message ? err.message : 'Conversion failed.', 'err');
+			setProgress(null);
+			window.__demoResult = { ok: false, error: String(err && err.message || err) };
+		} finally {
+			convertBtn.disabled = false;
+		}
+	});
+</script>
+</body>
+</html>


### PR DESCRIPTION
First off — thank you for this library! It's exactly what we needed for in-browser document conversion. 🙏

**Motivation.** The published package includes large browser binaries (`soffice.wasm` ≈ 140 MB, `soffice.data` ≈ 95 MB) that are hard to serve from a CDN and heavy to bundle in downstream projects. Public npm CDNs don't work for them (jsDelivr rejects the >150 MB package; unpkg returns `500` on the ~140 MB `soffice.wasm`), and GitHub release assets don't send CORS headers.

**This PR** adds an optional GitHub Actions workflow that publishes the browser runtime (`dist/` + `wasm/`) to **GitHub Pages**, which serves every file with `Access-Control-Allow-Origin: *`. Consumers can then load the WASM cross-origin instead of committing or bundling it. It also adds a tiny landing page with a **live in-browser conversion demo** (drop a file → PDF), using [`coi-serviceworker`](https://github.com/gzuidhof/coi-serviceworker) to enable `SharedArrayBuffer` on Pages (which can't set COOP/COEP headers).

**Live example** (deployed from our fork): https://erseco.github.io/libreoffice-document-converter/

Notes:
- Deploys via the Pages *artifact* (not a branch), so the 140 MB `soffice.wasm` isn't blocked by the 100 MB per-file git limit.
- Serves the latest published release; requires Pages enabled with the "GitHub Actions" source.
- Checkout pulls the LFS binaries — mind LFS/Pages bandwidth for heavy traffic.

Happy to tweak anything (the repo links on the landing page, workflow triggers, etc.) if you'd like to take it. Thanks again for the great work!
