### PR TITLE
Fix PDF/A export via JSON FilterData and subprocess pdf passthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matbee/libreoffice-converter",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matbee/libreoffice-converter",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "zod": "^4.1.13"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,6 +11,7 @@ export type {
   ConversionOptions,
   ConversionResult,
   FontData,
+  FilterOptions,
   ImageOptions,
   InputFormat,
   LibreOfficeWasmOptions,
@@ -72,6 +73,7 @@ import {
   FORMAT_FILTERS,
   FORMAT_MIME_TYPES,
   FORMAT_FILTER_OPTIONS,
+  buildPdfFilterOptions,
   OUTPUT_FORMAT_TO_LOK,
   BrowserConverterOptions,
   WorkerBrowserConverterOptions,
@@ -334,25 +336,10 @@ export class BrowserConverter {
 
       // Get LOK format string and filter options
       const lokFormat = OUTPUT_FORMAT_TO_LOK[outputExt];
-      let filterOptions = FORMAT_FILTER_OPTIONS[outputExt] || '';
+      let filterOptions = options.filterOptions ?? FORMAT_FILTER_OPTIONS[outputExt] ?? '';
 
-      // Add PDF-specific options
-      if (outputExt === 'pdf' && options.pdf) {
-        const pdfOpts: string[] = [];
-        if (options.pdf.pdfaLevel) {
-          const levelMap: Record<string, number> = {
-            'PDF/A-1b': 1,
-            'PDF/A-2b': 2,
-            'PDF/A-3b': 3,
-          };
-          pdfOpts.push(`SelectPdfVersion=${levelMap[options.pdf.pdfaLevel] || 0}`);
-        }
-        if (options.pdf.quality !== undefined) {
-          pdfOpts.push(`Quality=${options.pdf.quality}`);
-        }
-        if (pdfOpts.length > 0) {
-          filterOptions = pdfOpts.join(',');
-        }
+      if (!options.filterOptions && outputExt === 'pdf' && options.pdf) {
+        filterOptions = buildPdfFilterOptions(options.pdf) || filterOptions;
       }
 
       this.emitProgress('converting', 70, 'Saving...');
@@ -726,22 +713,9 @@ export class WorkerBrowserConverter implements ILibreOfficeConverter {
       throw new ConversionError(ConversionErrorCode.UNSUPPORTED_FORMAT, `Unsupported: ${outputExt}`);
     }
 
-    // Build filter options
-    let filterOptions = '';
-    if (outputExt === 'pdf' && options.pdf) {
-      const pdfOpts: string[] = [];
-      if (options.pdf.pdfaLevel) {
-        const levelMap: Record<string, number> = {
-          'PDF/A-1b': 1,
-          'PDF/A-2b': 2,
-          'PDF/A-3b': 3,
-        };
-        pdfOpts.push(`SelectPdfVersion=${levelMap[options.pdf.pdfaLevel] || 0}`);
-      }
-      if (options.pdf.quality !== undefined) {
-        pdfOpts.push(`Quality=${options.pdf.quality}`);
-      }
-      filterOptions = pdfOpts.join(',');
+    let filterOptions = options.filterOptions ?? '';
+    if (!options.filterOptions && outputExt === 'pdf' && options.pdf) {
+      filterOptions = buildPdfFilterOptions(options.pdf);
     }
 
     const result = await this.sendMessage('convert', {

--- a/src/converter-node.ts
+++ b/src/converter-node.ts
@@ -18,6 +18,7 @@ import {
   FORMAT_FILTERS,
   FORMAT_MIME_TYPES,
   FORMAT_FILTER_OPTIONS,
+  buildPdfFilterOptions,
   FullQualityPagePreview,
   FullQualityRenderOptions,
   ILibreOfficeConverter,
@@ -603,25 +604,10 @@ export class LibreOfficeConverter implements ILibreOfficeConverter {
       const lokFormat = OUTPUT_FORMAT_TO_LOK[options.outputFormat];
 
       // Get filter options for the format
-      let filterOptions = FORMAT_FILTER_OPTIONS[options.outputFormat] || '';
+      let filterOptions = options.filterOptions ?? FORMAT_FILTER_OPTIONS[options.outputFormat] ?? '';
 
-      // Add PDF-specific options if applicable
-      if (options.outputFormat === 'pdf' && options.pdf) {
-        const pdfOpts: string[] = [];
-        if (options.pdf.pdfaLevel) {
-          const levelMap: Record<string, number> = {
-            'PDF/A-1b': 1,
-            'PDF/A-2b': 2,
-            'PDF/A-3b': 3,
-          };
-          pdfOpts.push(`SelectPdfVersion=${levelMap[options.pdf.pdfaLevel] || 0}`);
-        }
-        if (options.pdf.quality !== undefined) {
-          pdfOpts.push(`Quality=${options.pdf.quality}`);
-        }
-        if (pdfOpts.length > 0) {
-          filterOptions = pdfOpts.join(',');
-        }
+      if (!options.filterOptions && options.outputFormat === 'pdf' && options.pdf) {
+        filterOptions = buildPdfFilterOptions(options.pdf) || filterOptions;
       }
 
       // Add page selection for image exports (png, jpg, svg)

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -18,6 +18,7 @@ import {
   FORMAT_FILTERS,
   FORMAT_MIME_TYPES,
   FORMAT_FILTER_OPTIONS,
+  buildPdfFilterOptions,
   FullQualityPagePreview,
   FullQualityRenderOptions,
   ILibreOfficeConverter,
@@ -572,25 +573,10 @@ export class LibreOfficeConverter implements ILibreOfficeConverter {
       const lokFormat = OUTPUT_FORMAT_TO_LOK[options.outputFormat];
       
       // Get filter options for the format
-      let filterOptions = FORMAT_FILTER_OPTIONS[options.outputFormat] || '';
-      
-      // Add PDF-specific options if applicable
-      if (options.outputFormat === 'pdf' && options.pdf) {
-        const pdfOpts: string[] = [];
-        if (options.pdf.pdfaLevel) {
-          const levelMap: Record<string, number> = {
-            'PDF/A-1b': 1,
-            'PDF/A-2b': 2,
-            'PDF/A-3b': 3,
-          };
-          pdfOpts.push(`SelectPdfVersion=${levelMap[options.pdf.pdfaLevel] || 0}`);
-        }
-        if (options.pdf.quality !== undefined) {
-          pdfOpts.push(`Quality=${options.pdf.quality}`);
-        }
-        if (pdfOpts.length > 0) {
-          filterOptions = pdfOpts.join(',');
-        }
+      let filterOptions = options.filterOptions ?? FORMAT_FILTER_OPTIONS[options.outputFormat] ?? '';
+
+      if (!options.filterOptions && options.outputFormat === 'pdf' && options.pdf) {
+        filterOptions = buildPdfFilterOptions(options.pdf) || filterOptions;
       }
 
       // Add page selection for image exports (png, jpg, svg)

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export type {
   ConversionOptions,
   ConversionResult,
   FontData,
+  FilterOptions,
   ImageOptions,
   InputFormat,
   LibreOfficeWasmOptions,

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,7 @@ export type {
   ConversionOptions,
   ConversionResult,
   FontData,
+  FilterOptions,
   ImageOptions,
   InputFormat,
   LibreOfficeWasmOptions,

--- a/src/subprocess.worker-converter.ts
+++ b/src/subprocess.worker-converter.ts
@@ -22,6 +22,7 @@ import {
   FullQualityRenderOptions,
   OUTPUT_FORMAT_TO_LOK,
   FORMAT_FILTER_OPTIONS,
+  buildPdfFilterOptions,
   ILibreOfficeConverter,
   InputFormatOptions,
   LibreOfficeWasmOptions,
@@ -238,12 +239,9 @@ export class SubprocessConverter implements ILibreOfficeConverter {
     if (data.length === 0) throw new ConversionError(ConversionErrorCode.INVALID_INPUT, 'Empty');
 
     const ext = options.inputFormat || (filename.includes('.') ? filename.slice(filename.lastIndexOf('.') + 1).toLowerCase() : 'docx');
-    let filter = FORMAT_FILTER_OPTIONS[options.outputFormat] || '';
-    if (options.outputFormat === 'pdf' && options.pdf) {
-      const o: string[] = [];
-      if (options.pdf.pdfaLevel) o.push(`SelectPdfVersion=${{ 'PDF/A-1b': 1, 'PDF/A-2b': 2, 'PDF/A-3b': 3 }[options.pdf.pdfaLevel] || 0}`);
-      if (options.pdf.quality !== undefined) o.push(`Quality=${options.pdf.quality}`);
-      if (o.length) filter = o.join(',');
+    let filterOptions = options.filterOptions ?? FORMAT_FILTER_OPTIONS[options.outputFormat] ?? '';
+    if (!options.filterOptions && options.outputFormat === 'pdf' && options.pdf) {
+      filterOptions = buildPdfFilterOptions(options.pdf) || filterOptions;
     }
 
     const maxRetries = this.options.maxConversionRetries || 2;
@@ -255,7 +253,7 @@ export class SubprocessConverter implements ILibreOfficeConverter {
           inputData: Array.from(data),
           inputExt: ext,
           outputFormat: OUTPUT_FORMAT_TO_LOK[options.outputFormat],
-          filterOptions: filter
+          filterOptions,
         }) as number[];
 
         const base = filename.includes('.') ? filename.slice(0, filename.lastIndexOf('.')) : filename;

--- a/src/subprocess.worker.cts
+++ b/src/subprocess.worker.cts
@@ -88,7 +88,7 @@ class NodeXHR {
 // Import converter and editor - these will be bundled by tsup
 import { LibreOfficeConverter } from './converter-node.js';
 import { createEditor, OfficeEditor } from './editor/index.js';
-import type { ConversionOptions, InputFormatOptions, WasmLoaderModule } from './types.js';
+import type { ConversionOptions, FilterOptions, InputFormatOptions, WasmLoaderModule } from './types.js';
 import { buildLoadOptions } from './types.js';
 import type { OperationResult } from './editor/types.js';
 
@@ -120,7 +120,7 @@ interface ConvertPayload {
   inputData: number[];
   inputExt: string;
   outputFormat: string;
-  filterOptions: string;
+  filterOptions?: FilterOptions;
 }
 
 interface DocumentPayload {
@@ -198,6 +198,7 @@ async function handleConvert(payload: ConvertPayload): Promise<number[]> {
     {
       inputFormat: payload.inputExt,
       outputFormat: payload.outputFormat,
+      filterOptions: payload.filterOptions,
     } as ConversionOptions,
     'document'
   );

--- a/src/types-entry.ts
+++ b/src/types-entry.ts
@@ -22,6 +22,7 @@ export type {
   OutputFormat,
   ConversionOptions,
   ConversionResult,
+  FilterOptions,
   PdfOptions,
   ImageOptions,
   ProgressInfo,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,11 @@ export type OutputFormat =
   | 'svg';
 
 /**
+ * LibreOfficeKit saveAs filter options (JSON FilterData or legacy key=value).
+ */
+export type FilterOptions = string;
+
+/**
  * Document conversion options
  */
 export interface ConversionOptions {
@@ -80,6 +85,12 @@ export interface ConversionOptions {
    * Password for encrypted documents
    */
   password?: string;
+
+  /**
+   * Raw LibreOfficeKit filter options string.
+   * When set, overrides options derived from format-specific fields like `pdf`.
+   */
+  filterOptions?: FilterOptions;
 }
 
 /**
@@ -96,6 +107,38 @@ export interface PdfOptions {
    * @default 90
    */
   quality?: number;
+}
+
+const PDFA_LEVEL_TO_VERSION: Record<NonNullable<PdfOptions['pdfaLevel']>, number> = {
+  'PDF/A-1b': 1,
+  'PDF/A-2b': 2,
+  'PDF/A-3b': 3,
+};
+
+/**
+ * Build LOK PDF filter options as JSON FilterData.
+ * LibreOfficeKit ignores legacy key=value strings for PDF export.
+ */
+export function buildPdfFilterOptions(pdf?: PdfOptions): string {
+  if (!pdf) return '';
+
+  const filterData: Record<string, { type: string; value: string }> = {};
+
+  if (pdf.pdfaLevel) {
+    filterData.SelectPdfVersion = {
+      type: 'long',
+      value: String(PDFA_LEVEL_TO_VERSION[pdf.pdfaLevel] ?? 0),
+    };
+  }
+
+  if (pdf.quality !== undefined) {
+    filterData.Quality = {
+      type: 'long',
+      value: String(pdf.quality),
+    };
+  }
+
+  return Object.keys(filterData).length > 0 ? JSON.stringify(filterData) : '';
 }
 
 /**
@@ -729,9 +772,8 @@ export const OUTPUT_FORMAT_TO_LOK: Record<OutputFormat, string> = {
  * These are passed to LibreOfficeKit's saveAs as the filterOptions parameter
  */
 export const FORMAT_FILTER_OPTIONS: Partial<Record<OutputFormat, string>> = {
-  // PDF options can include things like:
+  // PDF export options must be JSON FilterData (see buildPdfFilterOptions):
   // - SelectPdfVersion (0=PDF 1.4, 1=PDF/A-1, 2=PDF/A-2, 3=PDF/A-3)
-  // - UseLosslessCompression
   // - Quality
   pdf: '',
   // CSV can specify separator, encoding, etc.

--- a/tests/pdf-filter-options.test.ts
+++ b/tests/pdf-filter-options.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildPdfFilterOptions } from '../src/types.js';
+
+describe('buildPdfFilterOptions', () => {
+  it('returns empty string when no PDF options are provided', () => {
+    expect(buildPdfFilterOptions()).toBe('');
+    expect(buildPdfFilterOptions({})).toBe('');
+  });
+
+  it('builds JSON FilterData for PDF/A levels', () => {
+    expect(buildPdfFilterOptions({ pdfaLevel: 'PDF/A-1b' })).toBe(
+      JSON.stringify({ SelectPdfVersion: { type: 'long', value: '1' } })
+    );
+    expect(buildPdfFilterOptions({ pdfaLevel: 'PDF/A-2b' })).toBe(
+      JSON.stringify({ SelectPdfVersion: { type: 'long', value: '2' } })
+    );
+    expect(buildPdfFilterOptions({ pdfaLevel: 'PDF/A-3b' })).toBe(
+      JSON.stringify({ SelectPdfVersion: { type: 'long', value: '3' } })
+    );
+  });
+
+  it('builds JSON FilterData for quality', () => {
+    expect(buildPdfFilterOptions({ quality: 90 })).toBe(
+      JSON.stringify({ Quality: { type: 'long', value: '90' } })
+    );
+  });
+
+  it('combines PDF/A level and quality in one JSON object', () => {
+    const result = buildPdfFilterOptions({ pdfaLevel: 'PDF/A-2b', quality: 85 });
+    expect(JSON.parse(result)).toEqual({
+      SelectPdfVersion: { type: 'long', value: '2' },
+      Quality: { type: 'long', value: '85' },
+    });
+  });
+});

--- a/tests/subprocess.worker-converter.test.ts
+++ b/tests/subprocess.worker-converter.test.ts
@@ -314,6 +314,20 @@ describe('SubprocessConverter', () => {
         expect(result.data.length).toBeGreaterThan(0);
         expect(result.mimeType).toBe('application/pdf');
       });
+
+      it('should produce PDF/A metadata when pdfaLevel is set', async () => {
+        if (!converter?.isReady() || !fs.existsSync(testDocxPath)) return;
+
+        const docxData = fs.readFileSync(testDocxPath);
+        const result = await converter.convert(
+          docxData,
+          { inputFormat: 'docx', outputFormat: 'pdf', pdf: { pdfaLevel: 'PDF/A-2b' } },
+          'test.docx'
+        );
+
+        const pdfText = Buffer.from(result.data).toString('latin1');
+        expect(pdfText).toContain('pdfaid');
+      });
     });
 
     describe('getPageCount', () => {


### PR DESCRIPTION
- Build PDF filter options as JSON FilterData (`buildPdfFilterOptions`) instead of legacy `SelectPdfVersion=2` strings that LOK ignores
- Forward `pdf` options through the subprocess worker IPC path (they were previously dropped)