### PR TITLE
fix: WorkerConverter dropping conversion filter options

### DIFF
--- a/src/node.worker-converter.ts
+++ b/src/node.worker-converter.ts
@@ -18,6 +18,7 @@ import {
   DocumentInfo,
   EditorOperationResult,
   EditorSession,
+  FORMAT_FILTER_OPTIONS,
   FORMAT_MIME_TYPES,
   FullQualityPagePreview,
   FullQualityRenderOptions,
@@ -28,6 +29,7 @@ import {
   OutputFormat,
   PagePreview,
   RenderOptions,
+  buildPdfFilterOptions,
 } from './types.js';
 
 // Re-export types used by consumers
@@ -244,10 +246,16 @@ export class WorkerConverter implements ILibreOfficeConverter {
     const inputFormat = options.inputFormat || this.getExtensionFromFilename(filename) || 'docx';
     const outputFormat = options.outputFormat;
 
+    let filterOptions = options.filterOptions ?? FORMAT_FILTER_OPTIONS[outputFormat] ?? '';
+    if (!options.filterOptions && outputFormat === 'pdf' && options.pdf) {
+      filterOptions = buildPdfFilterOptions(options.pdf) || filterOptions;
+    }
+
     const result = await this.sendMessage('convert', {
       inputData,
       inputFormat,
       outputFormat,
+      filterOptions,
       filename,
     });
 

--- a/src/node.worker.ts
+++ b/src/node.worker.ts
@@ -11,7 +11,7 @@
 import { parentPort } from 'worker_threads';
 import { LibreOfficeConverter } from './converter-node.js';
 import { createEditor, OfficeEditor } from './editor/index.js';
-import type { ConversionOptions, InputFormatOptions, WasmLoaderModule } from './types.js';
+import type { ConversionOptions, FilterOptions, InputFormatOptions, WasmLoaderModule } from './types.js';
 import { buildLoadOptions } from './types.js';
 import type { OperationResult } from './editor/types.js';
 
@@ -34,7 +34,7 @@ interface ConvertPayload {
   inputData: Uint8Array;
   inputFormat: string;
   outputFormat: string;
-  filterOptions?: string;
+  filterOptions?: FilterOptions;
   filename?: string;
 }
 
@@ -127,6 +127,7 @@ async function handleConvert(payload: ConvertPayload): Promise<Uint8Array> {
   const options: ConversionOptions = {
     inputFormat: payload.inputFormat as ConversionOptions['inputFormat'],
     outputFormat: payload.outputFormat as ConversionOptions['outputFormat'],
+    filterOptions: payload.filterOptions,
   };
 
   const result = await converter.convert(

--- a/tests/worker-converter.test.ts
+++ b/tests/worker-converter.test.ts
@@ -314,6 +314,20 @@ describe.skip('WorkerConverter', () => {
         expect(result.data.length).toBeGreaterThan(0);
         expect(result.mimeType).toBe('application/pdf');
       });
+
+      it('should produce PDF/A metadata when pdfaLevel is set', async () => {
+        if (!converter?.isReady() || !fs.existsSync(testDocxPath)) return;
+
+        const docxData = fs.readFileSync(testDocxPath);
+        const result = await converter.convert(
+          docxData,
+          { inputFormat: 'docx', outputFormat: 'pdf', pdf: { pdfaLevel: 'PDF/A-2b' } },
+          'test.docx'
+        );
+
+        const pdfText = Buffer.from(result.data).toString('latin1');
+        expect(pdfText).toContain('pdfaid');
+      });
     });
 
     describe('getPageCount', () => {


### PR DESCRIPTION
WorkerConverter.convert() only sent inputFormat/outputFormat to the worker thread, silently dropping conversion options such as filterOptions and format-specific settings (e.g. pdf.pdfaLevel). Build filterOptions in the parent and forward them through node.worker.ts to converter.convert().